### PR TITLE
fix: add rhel-openssl-3.0.x to binaryTargets for Vercel

### DIFF
--- a/app/history/_components/QuestionsHistory.tsx
+++ b/app/history/_components/QuestionsHistory.tsx
@@ -64,7 +64,7 @@ function useUserAnswers() {
         const answers = await getUserAnswers()
         setUserAnswers(answers)
         setAnsweredQuestionIds(Object.keys(answers))
-      } catch (error) {
+      } catch {
         setUserAnswers({})
         setAnsweredQuestionIds([])
       } finally {
@@ -108,7 +108,7 @@ function useQuestionsData(answeredQuestionIds: string[], userAnswers: Record<str
               }))
             )
           }
-        } catch { }
+        } catch {}
       }
 
       return allQuestions
@@ -124,14 +124,14 @@ function useDisciplines(): Discipline[] {
 
   return examsData
     ? Array.from(
-      examsData
-        .flatMap((exam: Exam) => exam.disciplines)
-        .reduce(
-          (map: Map<string, Discipline>, discipline: Discipline) => map.set(discipline.value, discipline),
-          new Map<string, Discipline>()
-        )
-        .values()
-    )
+        examsData
+          .flatMap((exam: Exam) => exam.disciplines)
+          .reduce(
+            (map: Map<string, Discipline>, discipline: Discipline) => map.set(discipline.value, discipline),
+            new Map<string, Discipline>()
+          )
+          .values()
+      )
     : []
 }
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -486,7 +486,7 @@ const SidebarMenuAction = React.forwardRef<
         'peer-data-[size=lg]/menu-button:top-2.5',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
-        'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
         className
       )}
       {...props}

--- a/lib/generated/prisma/edge.js
+++ b/lib/generated/prisma/edge.js
@@ -196,6 +196,14 @@ const config = {
       },
       {
         "fromEnvVar": null,
+        "value": "debian-openssl-3.0.x"
+      },
+      {
+        "fromEnvVar": null,
+        "value": "rhel-openssl-3.0.x"
+      },
+      {
+        "fromEnvVar": null,
         "value": "linux-musl-openssl-3.0.x"
       }
     ],
@@ -204,7 +212,7 @@ const config = {
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": null,
+    "rootEnvPath": "../../../.env",
     "schemaEnvPath": "../../../.env"
   },
   "relativePath": "../../../prisma",
@@ -214,7 +222,7 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": true,
+  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {
@@ -223,8 +231,8 @@ const config = {
       }
     }
   },
-  "inlineSchema": "// This is your Prisma schema file,\n// learn more about it in the docs: https://pris.ly/d/prisma-schema\n\n// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?\n// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init\n\ngenerator client {\n  provider      = \"prisma-client-js\"\n  output        = \"../lib/generated/prisma\"\n  binaryTargets = [\"native\", \"linux-musl-openssl-3.0.x\"]\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel User {\n  id            String       @id\n  name          String\n  email         String\n  emailVerified Boolean\n  image         String?\n  createdAt     DateTime\n  updatedAt     DateTime\n  sessions      Session[]\n  accounts      Account[]\n  userAnswers   UserAnswer[]\n\n  @@unique([email])\n  @@map(\"user\")\n}\n\nmodel Session {\n  id        String   @id\n  expiresAt DateTime\n  token     String\n  createdAt DateTime\n  updatedAt DateTime\n  ipAddress String?\n  userAgent String?\n  userId    String\n  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n\n  @@unique([token])\n  @@map(\"session\")\n}\n\nmodel Account {\n  id                    String    @id\n  accountId             String\n  providerId            String\n  userId                String\n  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)\n  accessToken           String?\n  refreshToken          String?\n  idToken               String?\n  accessTokenExpiresAt  DateTime?\n  refreshTokenExpiresAt DateTime?\n  scope                 String?\n  password              String?\n  createdAt             DateTime\n  updatedAt             DateTime\n\n  @@map(\"account\")\n}\n\nmodel Verification {\n  id         String    @id\n  identifier String\n  value      String\n  expiresAt  DateTime\n  createdAt  DateTime?\n  updatedAt  DateTime?\n\n  @@map(\"verification\")\n}\n\nmodel UserAnswer {\n  id          String   @id @default(cuid())\n  userId      String\n  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n  questionId  String\n  answerIndex Int\n  isCorrect   Boolean\n  createdAt   DateTime @default(now())\n  updatedAt   DateTime @updatedAt\n\n  @@unique([userId, questionId])\n  @@map(\"user_answer\")\n}\n",
-  "inlineSchemaHash": "c41b32a5de19ed7fca573af25fe8d611ea3243f68860dad97ca3aed635e7cf23",
+  "inlineSchema": "// This is your Prisma schema file,\n// learn more about it in the docs: https://pris.ly/d/prisma-schema\n\n// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?\n// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init\n\ngenerator client {\n  provider      = \"prisma-client-js\"\n  output        = \"../lib/generated/prisma\"\n  binaryTargets = [\"native\", \"debian-openssl-3.0.x\", \"rhel-openssl-3.0.x\", \"linux-musl-openssl-3.0.x\"]\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel User {\n  id            String       @id\n  name          String\n  email         String\n  emailVerified Boolean\n  image         String?\n  createdAt     DateTime\n  updatedAt     DateTime\n  sessions      Session[]\n  accounts      Account[]\n  userAnswers   UserAnswer[]\n\n  @@unique([email])\n  @@map(\"user\")\n}\n\nmodel Session {\n  id        String   @id\n  expiresAt DateTime\n  token     String\n  createdAt DateTime\n  updatedAt DateTime\n  ipAddress String?\n  userAgent String?\n  userId    String\n  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n\n  @@unique([token])\n  @@map(\"session\")\n}\n\nmodel Account {\n  id                    String    @id\n  accountId             String\n  providerId            String\n  userId                String\n  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)\n  accessToken           String?\n  refreshToken          String?\n  idToken               String?\n  accessTokenExpiresAt  DateTime?\n  refreshTokenExpiresAt DateTime?\n  scope                 String?\n  password              String?\n  createdAt             DateTime\n  updatedAt             DateTime\n\n  @@map(\"account\")\n}\n\nmodel Verification {\n  id         String    @id\n  identifier String\n  value      String\n  expiresAt  DateTime\n  createdAt  DateTime?\n  updatedAt  DateTime?\n\n  @@map(\"verification\")\n}\n\nmodel UserAnswer {\n  id          String   @id @default(cuid())\n  userId      String\n  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n  questionId  String\n  answerIndex Int\n  isCorrect   Boolean\n  createdAt   DateTime @default(now())\n  updatedAt   DateTime @updatedAt\n\n  @@unique([userId, questionId])\n  @@map(\"user_answer\")\n}\n",
+  "inlineSchemaHash": "91f50c906ef2aac61b89d75f62c11c4e62a0892ebad55e9d59c1e581d14639d8",
   "copyEngine": true
 }
 config.dirname = '/'

--- a/lib/generated/prisma/index.js
+++ b/lib/generated/prisma/index.js
@@ -197,6 +197,14 @@ const config = {
       },
       {
         "fromEnvVar": null,
+        "value": "debian-openssl-3.0.x"
+      },
+      {
+        "fromEnvVar": null,
+        "value": "rhel-openssl-3.0.x"
+      },
+      {
+        "fromEnvVar": null,
         "value": "linux-musl-openssl-3.0.x"
       }
     ],
@@ -205,7 +213,7 @@ const config = {
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": null,
+    "rootEnvPath": "../../../.env",
     "schemaEnvPath": "../../../.env"
   },
   "relativePath": "../../../prisma",
@@ -215,7 +223,7 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": true,
+  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {
@@ -224,8 +232,8 @@ const config = {
       }
     }
   },
-  "inlineSchema": "// This is your Prisma schema file,\n// learn more about it in the docs: https://pris.ly/d/prisma-schema\n\n// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?\n// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init\n\ngenerator client {\n  provider      = \"prisma-client-js\"\n  output        = \"../lib/generated/prisma\"\n  binaryTargets = [\"native\", \"linux-musl-openssl-3.0.x\"]\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel User {\n  id            String       @id\n  name          String\n  email         String\n  emailVerified Boolean\n  image         String?\n  createdAt     DateTime\n  updatedAt     DateTime\n  sessions      Session[]\n  accounts      Account[]\n  userAnswers   UserAnswer[]\n\n  @@unique([email])\n  @@map(\"user\")\n}\n\nmodel Session {\n  id        String   @id\n  expiresAt DateTime\n  token     String\n  createdAt DateTime\n  updatedAt DateTime\n  ipAddress String?\n  userAgent String?\n  userId    String\n  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n\n  @@unique([token])\n  @@map(\"session\")\n}\n\nmodel Account {\n  id                    String    @id\n  accountId             String\n  providerId            String\n  userId                String\n  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)\n  accessToken           String?\n  refreshToken          String?\n  idToken               String?\n  accessTokenExpiresAt  DateTime?\n  refreshTokenExpiresAt DateTime?\n  scope                 String?\n  password              String?\n  createdAt             DateTime\n  updatedAt             DateTime\n\n  @@map(\"account\")\n}\n\nmodel Verification {\n  id         String    @id\n  identifier String\n  value      String\n  expiresAt  DateTime\n  createdAt  DateTime?\n  updatedAt  DateTime?\n\n  @@map(\"verification\")\n}\n\nmodel UserAnswer {\n  id          String   @id @default(cuid())\n  userId      String\n  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n  questionId  String\n  answerIndex Int\n  isCorrect   Boolean\n  createdAt   DateTime @default(now())\n  updatedAt   DateTime @updatedAt\n\n  @@unique([userId, questionId])\n  @@map(\"user_answer\")\n}\n",
-  "inlineSchemaHash": "c41b32a5de19ed7fca573af25fe8d611ea3243f68860dad97ca3aed635e7cf23",
+  "inlineSchema": "// This is your Prisma schema file,\n// learn more about it in the docs: https://pris.ly/d/prisma-schema\n\n// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?\n// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init\n\ngenerator client {\n  provider      = \"prisma-client-js\"\n  output        = \"../lib/generated/prisma\"\n  binaryTargets = [\"native\", \"debian-openssl-3.0.x\", \"rhel-openssl-3.0.x\", \"linux-musl-openssl-3.0.x\"]\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel User {\n  id            String       @id\n  name          String\n  email         String\n  emailVerified Boolean\n  image         String?\n  createdAt     DateTime\n  updatedAt     DateTime\n  sessions      Session[]\n  accounts      Account[]\n  userAnswers   UserAnswer[]\n\n  @@unique([email])\n  @@map(\"user\")\n}\n\nmodel Session {\n  id        String   @id\n  expiresAt DateTime\n  token     String\n  createdAt DateTime\n  updatedAt DateTime\n  ipAddress String?\n  userAgent String?\n  userId    String\n  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n\n  @@unique([token])\n  @@map(\"session\")\n}\n\nmodel Account {\n  id                    String    @id\n  accountId             String\n  providerId            String\n  userId                String\n  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)\n  accessToken           String?\n  refreshToken          String?\n  idToken               String?\n  accessTokenExpiresAt  DateTime?\n  refreshTokenExpiresAt DateTime?\n  scope                 String?\n  password              String?\n  createdAt             DateTime\n  updatedAt             DateTime\n\n  @@map(\"account\")\n}\n\nmodel Verification {\n  id         String    @id\n  identifier String\n  value      String\n  expiresAt  DateTime\n  createdAt  DateTime?\n  updatedAt  DateTime?\n\n  @@map(\"verification\")\n}\n\nmodel UserAnswer {\n  id          String   @id @default(cuid())\n  userId      String\n  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)\n  questionId  String\n  answerIndex Int\n  isCorrect   Boolean\n  createdAt   DateTime @default(now())\n  updatedAt   DateTime @updatedAt\n\n  @@unique([userId, questionId])\n  @@map(\"user_answer\")\n}\n",
+  "inlineSchemaHash": "91f50c906ef2aac61b89d75f62c11c4e62a0892ebad55e9d59c1e581d14639d8",
   "copyEngine": true
 }
 
@@ -266,6 +274,10 @@ Object.assign(exports, Prisma)
 // file annotations for bundling tools to include these files
 path.join(__dirname, "libquery_engine-debian-openssl-3.0.x.so.node");
 path.join(process.cwd(), "lib/generated/prisma/libquery_engine-debian-openssl-3.0.x.so.node")
+
+// file annotations for bundling tools to include these files
+path.join(__dirname, "libquery_engine-rhel-openssl-3.0.x.so.node");
+path.join(process.cwd(), "lib/generated/prisma/libquery_engine-rhel-openssl-3.0.x.so.node")
 
 // file annotations for bundling tools to include these files
 path.join(__dirname, "libquery_engine-linux-musl-openssl-3.0.x.so.node");

--- a/lib/generated/prisma/package.json
+++ b/lib/generated/prisma/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prisma-client-07939635c66e3bb206d7dd8a62b85a25de4201a9299d7d95fd04d11e394c556c",
+  "name": "prisma-client-5c8b231ce314cb61b51f1e883a7c4de8eb3506ab474e6ca7aa8d21aeaff5dc8a",
   "main": "index.js",
   "types": "index.d.ts",
   "browser": "index-browser.js",

--- a/lib/generated/prisma/schema.prisma
+++ b/lib/generated/prisma/schema.prisma
@@ -7,7 +7,7 @@
 generator client {
   provider      = "prisma-client-js"
   output        = "../lib/generated/prisma"
-  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
+  binaryTargets = ["native", "debian-openssl-3.0.x", "rhel-openssl-3.0.x", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@
 generator client {
   provider = "prisma-client-js"
   output   = "../lib/generated/prisma"
-  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
+binaryTargets = ["native", "debian-openssl-3.0.x", "rhel-openssl-3.0.x", "linux-musl-openssl-3.0.x"] 
 }
 
 datasource db {


### PR DESCRIPTION
fix error:
```
2025-07-17T05:25:38.632Z [error] Unhandled Rejection: Error [PrismaClientInitializationError]: Prisma Client could not locate the Query Engine for runtime "rhel-openssl-3.0.x".

This happened because Prisma Client was generated for "debian-openssl-3.0.x", but the actual deployment required "rhel-openssl-3.0.x".
Add "rhel-openssl-3.0.x" to `binaryTargets` in the "schema.prisma" file and run `prisma generate` after saving it:

generator client {
  provider      = "prisma-client-js"
  binaryTargets = ["native", "linux-musl-openssl-3.0.x", "rhel-openssl-3.0.x"]
}

The following locations have been searched:
  /var/task/lib/generated/prisma
  /var/task/.next/server
  /home/riann/dev/questoes-enem/lib/generated/prisma
  /var/task/.prisma/client
  /tmp/prisma-engines
  /var/task/prisma
    at ac (.next/server/chunks/977.js:30:1106)
    at async Object.loadLibrary (.next/server/chunks/977.js:55:9563)
    at async ou.loadEngine (.next/server/chunks/977.js:59:450)
    at async ou.instantiateLibrary (.next/server/chunks/977.js:58:4246)
    at async ou.start (.next/server/chunks/977.js:59:2129) {
  clientVersion: '6.10.1',
  errorCode: undefined
}
2025-07-17T05:25:38.632Z [fatal] Node.js process exited with exit status: 128. The logs above can help with debugging the issue.
```